### PR TITLE
Add support for all types of content in QR codes

### DIFF
--- a/android/src/main/java/com/visioncameraqrcodescanner/BarcodeConverter.java
+++ b/android/src/main/java/com/visioncameraqrcodescanner/BarcodeConverter.java
@@ -1,0 +1,242 @@
+package com.visioncameraqrcodescanner;
+
+import android.graphics.Point;
+import android.graphics.Rect;
+
+import androidx.annotation.NonNull;
+
+import com.facebook.react.bridge.WritableNativeArray;
+import com.facebook.react.bridge.WritableNativeMap;
+import com.google.mlkit.vision.barcode.Barcode;
+
+import java.util.List;
+
+/**
+ * Converter util class used to convert Barcode related variables to either WritableNativeArray or
+ * WritableNativeMap
+ */
+public class BarcodeConverter {
+  public static WritableNativeArray convertToArray(@NonNull Point[] points) {
+    WritableNativeArray array = new WritableNativeArray();
+
+    for (Point point: points) {
+      array.pushMap(convertToMap(point));
+    }
+
+    return array;
+  }
+
+  public static WritableNativeArray convertToArray(@NonNull String[] elements) {
+    WritableNativeArray array = new WritableNativeArray();
+
+    for (String elem: elements) {
+      array.pushString(elem);
+    }
+
+    return array;
+  }
+
+  public static WritableNativeArray convertStringList(@NonNull List<String> elements) {
+    WritableNativeArray array = new WritableNativeArray();
+
+    for (String elem: elements) {
+      array.pushString(elem);
+    }
+
+    return array;
+  }
+
+  public static WritableNativeArray convertAddressList(@NonNull List<Barcode.Address> addresses) {
+    WritableNativeArray array = new WritableNativeArray();
+
+    for (Barcode.Address address: addresses) {
+      array.pushMap(convertToMap(address));
+    }
+
+    return array;
+  }
+
+  public static WritableNativeArray convertPhoneList(@NonNull List<Barcode.Phone> phones) {
+    WritableNativeArray array = new WritableNativeArray();
+
+    for (Barcode.Phone phone: phones) {
+      array.pushMap(convertToMap(phone));
+    }
+
+    return array;
+  }
+
+  public static WritableNativeArray convertEmailList(@NonNull List<Barcode.Email> emails) {
+    WritableNativeArray array = new WritableNativeArray();
+
+    for (Barcode.Email email: emails) {
+      array.pushMap(convertToMap(email));
+    }
+
+    return array;
+  }
+
+  public static WritableNativeMap convertToMap(@NonNull Point point) {
+    WritableNativeMap map = new WritableNativeMap();
+
+    map.putInt("x", point.x);
+    map.putInt("y", point.y);
+
+    return map;
+  }
+
+  public static WritableNativeMap convertToMap(@NonNull Barcode.Address address) {
+    WritableNativeMap map = new WritableNativeMap();
+
+    map.putArray("addressLines", convertToArray(address.getAddressLines()));
+    map.putInt("type", address.getType());
+
+    return map;
+  }
+
+  public static WritableNativeMap convertToMap(@NonNull Rect rect) {
+    WritableNativeMap map = new WritableNativeMap();
+
+    map.putInt("bottom", rect.bottom);
+    map.putInt("left", rect.left);
+    map.putInt("right", rect.right);
+    map.putInt("top", rect.top);
+
+    return map;
+  }
+
+  public static WritableNativeMap convertToMap(@NonNull Barcode.ContactInfo contactInfo) {
+    WritableNativeMap map = new WritableNativeMap();
+
+    map.putArray("addresses", convertAddressList(contactInfo.getAddresses()));
+    map.putArray("emails", convertEmailList(contactInfo.getEmails()));
+    map.putMap("name", convertToMap(contactInfo.getName()));
+    map.putString("organization", contactInfo.getOrganization());
+    map.putArray("phones", convertPhoneList(contactInfo.getPhones()));
+    map.putString("title", contactInfo.getTitle());
+    map.putArray("urls", convertStringList(contactInfo.getUrls()));
+
+    return map;
+  }
+
+  public static WritableNativeMap convertToMap(@NonNull Barcode.PersonName name) {
+    WritableNativeMap map = new WritableNativeMap();
+
+    map.putString("first", name.getFirst());
+    map.putString("formattedName", name.getFormattedName());
+    map.putString("last", name.getLast());
+    map.putString("middle", name.getMiddle());
+    map.putString("prefix", name.getPrefix());
+    map.putString("pronunciation", name.getPronunciation());
+    map.putString("suffix", name.getSuffix());
+
+    return map;
+  }
+
+  public static WritableNativeMap convertToMap(@NonNull Barcode.UrlBookmark url) {
+    WritableNativeMap map = new WritableNativeMap();
+
+    map.putString("title", url.getTitle());
+    map.putString("url", url.getUrl());
+
+    return map;
+  }
+
+  public static WritableNativeMap convertToMap(@NonNull Barcode.Email email) {
+    WritableNativeMap map = new WritableNativeMap();
+
+    map.putString("address", email.getAddress());
+    map.putString("body", email.getBody());
+    map.putString("subject", email.getSubject());
+    map.putInt("type", email.getType());
+
+    return map;
+  }
+
+  public static WritableNativeMap convertToMap(@NonNull Barcode.Phone phone) {
+    WritableNativeMap map = new WritableNativeMap();
+
+    map.putString("number", phone.getNumber());
+    map.putInt("type", phone.getType());
+
+    return map;
+  }
+
+  public static WritableNativeMap convertToMap(@NonNull Barcode.Sms sms) {
+    WritableNativeMap map = new WritableNativeMap();
+
+    map.putString("message", sms.getMessage());
+    map.putString("phoneNumber", sms.getPhoneNumber());
+
+    return map;
+  }
+
+  public static WritableNativeMap convertToMap(@NonNull Barcode.WiFi wifi) {
+    WritableNativeMap map = new WritableNativeMap();
+
+    map.putInt("encryptionType", wifi.getEncryptionType());
+    map.putString("password", wifi.getPassword());
+    map.putString("ssid", wifi.getSsid());
+
+    return map;
+  }
+
+  public static WritableNativeMap convertToMap(@NonNull Barcode.GeoPoint geoPoint) {
+    WritableNativeMap map = new WritableNativeMap();
+
+    map.putDouble("lat", geoPoint.getLat());
+    map.putDouble("lng", geoPoint.getLng());
+
+    return map;
+  }
+
+  public static WritableNativeMap convertToMap(@NonNull Barcode.CalendarDateTime calendarDateTime) {
+    WritableNativeMap map = new WritableNativeMap();
+
+    map.putInt("day", calendarDateTime.getDay());
+    map.putInt("hours", calendarDateTime.getHours());
+    map.putInt("minutes", calendarDateTime.getMinutes());
+    map.putInt("month", calendarDateTime.getMonth());
+    map.putString("rawValue", calendarDateTime.getRawValue());
+    map.putInt("year", calendarDateTime.getYear());
+    map.putInt("seconds", calendarDateTime.getSeconds());
+    map.putBoolean("isUtc", calendarDateTime.isUtc());
+
+    return map;
+  }
+
+  public static WritableNativeMap convertToMap(@NonNull Barcode.CalendarEvent calendarEvent) {
+    WritableNativeMap map = new WritableNativeMap();
+
+    map.putString("description", calendarEvent.getDescription());
+    map.putMap("end", convertToMap(calendarEvent.getEnd()));
+    map.putString("location", calendarEvent.getLocation());
+    map.putString("organizer", calendarEvent.getOrganizer());
+    map.putMap("start", convertToMap(calendarEvent.getStart()));
+    map.putString("status", calendarEvent.getStatus());
+    map.putString("summary", calendarEvent.getSummary());
+
+    return map;
+  }
+
+  public static WritableNativeMap convertToMap(@NonNull Barcode.DriverLicense driverLicense) {
+    WritableNativeMap map = new WritableNativeMap();
+
+    map.putString("addressCity", driverLicense.getAddressCity());
+    map.putString("addressState", driverLicense.getAddressState());
+    map.putString("addressStreet", driverLicense.getAddressStreet());
+    map.putString("addressZip", driverLicense.getAddressZip());
+    map.putString("birthDate", driverLicense.getBirthDate());
+    map.putString("documentType", driverLicense.getDocumentType());
+    map.putString("expiryDate", driverLicense.getExpiryDate());
+    map.putString("firstName", driverLicense.getFirstName());
+    map.putString("gender", driverLicense.getGender());
+    map.putString("issueDate", driverLicense.getIssueDate());
+    map.putString("issuingCountry", driverLicense.getIssuingCountry());
+    map.putString("lastName", driverLicense.getLastName());
+    map.putString("licenseNumber", driverLicense.getLicenseNumber());
+    map.putString("middleName", driverLicense.getMiddleName());
+
+    return map;
+  }
+}

--- a/android/src/main/java/com/visioncameraqrcodescanner/VisionCameraQrcodeScannerPlugin.java
+++ b/android/src/main/java/com/visioncameraqrcodescanner/VisionCameraQrcodeScannerPlugin.java
@@ -70,7 +70,7 @@ public class VisionCameraQrcodeScannerPlugin extends FrameProcessorPlugin {
       case Barcode.TYPE_UNKNOWN:
       case Barcode.TYPE_ISBN:
       case Barcode.TYPE_TEXT:
-        map.putString("content", barcode.getDisplayValue());
+        map.putString("content", barcode.getRawValue());
         break;
       case Barcode.TYPE_CONTACT_INFO:
         map.putMap("content", convertToMap(barcode.getContactInfo()));

--- a/android/src/main/java/com/visioncameraqrcodescanner/VisionCameraQrcodeScannerPlugin.java
+++ b/android/src/main/java/com/visioncameraqrcodescanner/VisionCameraQrcodeScannerPlugin.java
@@ -1,11 +1,17 @@
 package com.visioncameraqrcodescanner;
 
+import static com.visioncameraqrcodescanner.BarcodeConverter.convertToArray;
+import static com.visioncameraqrcodescanner.BarcodeConverter.convertToMap;
+
 import android.annotation.SuppressLint;
+import android.graphics.Point;
+import android.graphics.Rect;
 import android.media.Image;
 
 import com.facebook.react.bridge.WritableNativeArray;
 import com.facebook.react.bridge.WritableNativeMap;
 
+import androidx.annotation.NonNull;
 import androidx.camera.core.ImageProxy;
 
 import com.google.android.gms.tasks.Tasks;
@@ -21,6 +27,8 @@ import com.google.mlkit.vision.common.InputImage;
 import java.util.List;
 
 public class VisionCameraQrcodeScannerPlugin extends FrameProcessorPlugin {
+  // Note that if you know which format of barcode your app is dealing with, detection will be
+  // faster than specify the supported barcode formats one by one, e.g.
   private final BarcodeScanner barcodeScanner =
     BarcodeScanning.getClient(
       new BarcodeScannerOptions.Builder()
@@ -29,14 +37,8 @@ public class VisionCameraQrcodeScannerPlugin extends FrameProcessorPlugin {
       )
       .build());
 
-
   @Override
   public Object callback(ImageProxy frame, Object[] params) {
-    // Note that if you know which format of barcode your app is dealing with, detection will be
-    // faster than specify the supported barcode formats one by one, e.g.
-    // BarcodeScannerOptions.Builder()
-    //     .setBarcodeFormats(Barcode.FORMAT_QR_CODE)
-    //     .build();
     @SuppressLint("UnsafeOptInUsageError")
     Image mediaImage = frame.getImage();
     if (mediaImage != null) {
@@ -48,16 +50,7 @@ public class VisionCameraQrcodeScannerPlugin extends FrameProcessorPlugin {
 
         WritableNativeArray array = new WritableNativeArray();
         for (Barcode barcode: barcodes) {
-          WritableNativeMap map = new WritableNativeMap();
-          int valueType = barcode.getValueType();
-          // See API reference for complete list of supported types
-          switch (valueType) {
-            case Barcode.TYPE_URL:
-              map.putString("title", barcode.getUrl().getTitle());
-              map.putString("url",barcode.getUrl().getUrl());
-              break;
-          }
-          array.pushMap(map);
+          array.pushMap(convertBarcode(barcode));
         }
         return array;
       } catch (Exception e) {
@@ -65,9 +58,79 @@ public class VisionCameraQrcodeScannerPlugin extends FrameProcessorPlugin {
       }
     }
     return null;
-
   }
 
+  private WritableNativeMap convertContent(@NonNull Barcode barcode) {
+    WritableNativeMap map = new WritableNativeMap();
+
+    int type = barcode.getValueType();
+    map.putInt("type", type);
+
+    switch (type) {
+      case Barcode.TYPE_UNKNOWN:
+      case Barcode.TYPE_ISBN:
+      case Barcode.TYPE_TEXT:
+        map.putString("content", barcode.getDisplayValue());
+        break;
+      case Barcode.TYPE_CONTACT_INFO:
+        map.putMap("content", convertToMap(barcode.getContactInfo()));
+        break;
+      case Barcode.TYPE_EMAIL:
+        map.putMap("content", convertToMap(barcode.getEmail()));
+        break;
+      case Barcode.TYPE_PHONE:
+        map.putMap("content", convertToMap(barcode.getPhone()));
+        break;
+      case Barcode.TYPE_SMS:
+        map.putMap("content", convertToMap(barcode.getSms()));
+        break;
+      case Barcode.TYPE_URL:
+        map.putMap("content", convertToMap(barcode.getUrl()));
+        break;
+      case Barcode.TYPE_WIFI:
+        map.putMap("content", convertToMap(barcode.getWifi()));
+        break;
+      case Barcode.TYPE_GEO:
+        map.putMap("content", convertToMap(barcode.getGeoPoint()));
+        break;
+      case Barcode.TYPE_CALENDAR_EVENT:
+        map.putMap("content", convertToMap(barcode.getCalendarEvent()));
+        break;
+      case Barcode.TYPE_DRIVER_LICENSE:
+        map.putMap("content", convertToMap(barcode.getDriverLicense()));
+        break;
+    }
+
+    return map;
+  }
+
+  private WritableNativeMap convertBarcode(@NonNull Barcode barcode) {
+    WritableNativeMap map = new WritableNativeMap();
+
+    Rect boundingBox = barcode.getBoundingBox();
+    if (boundingBox != null) {
+      map.putMap("boundingBox", convertToMap(boundingBox));
+    }
+
+    Point[] cornerPoints = barcode.getCornerPoints();
+    if (cornerPoints != null) {
+      map.putArray("cornerPoints", convertToArray(cornerPoints));
+    }
+
+    String displayValue = barcode.getDisplayValue();
+    if (displayValue != null) {
+      map.putString("displayValue", displayValue);
+    }
+
+    String rawValue = barcode.getRawValue();
+    if (rawValue != null) {
+      map.putString("rawValue", rawValue);
+    }
+
+    map.putMap("content", convertContent(barcode));
+
+    return map;
+  }
 
   VisionCameraQrcodeScannerPlugin() {
     super("scanQRCodes");

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -26,6 +26,7 @@ export default function App() {
     'worklet';
     const qrcode = scanQRCodes(frame);
     runOnJS(setQrCodes)(qrcode);
+    console.log(qrCodes);
   }, []);
 
   return (
@@ -41,7 +42,7 @@ export default function App() {
         />
         {qrCodes.map((qrcode, idx) => (
           <Text key={idx} style={styles.qrCodeTextURL}>
-            {qrcode.url}
+            {qrcode.displayValue}
           </Text>
         ))}
       </>

--- a/ios/BarcodeConverter.swift
+++ b/ios/BarcodeConverter.swift
@@ -1,0 +1,133 @@
+import MLKitBarcodeScanning
+
+class BarcodeConverter {
+    public static func convertToMap(url: BarcodeURLBookmark) -> Any! {
+        var map: [String: Any] = [:]
+
+        map["title"] = url?.title
+        map["url"] = url?.url
+
+        return map
+    }
+
+    public static func convertToMap(wifi: BarcodeWifi) -> Any! {
+        var map: [String: Any] = [:]
+
+        map["encryptionType"] = wifi?.type
+        map["password"] = wifi?.password
+        map["ssid"] = wifi?.ssid
+
+        return map
+    }
+
+    public static func convertToMap(sms: BarcodeSMS) -> Any! {
+        var map: [String: Any] = [:]
+
+        map["message"] = sms?.message
+        map["phoneNumber"] = sms?.phoneNumber
+
+        return map
+    }
+
+    public static func convertToMap(phone: BarcodePhone) -> Any! {
+        var map: [String: Any] = [:]
+
+        map["number"] = phone?.number
+        map["type"] = phone?.type
+
+        return map
+    }
+
+    public static func convertToMap(geoPoint: BarcodeGeoPoint) -> Any! {
+        var map: [String: Any] = [:]
+
+        map["lat"] = geoPoint?.latitude
+        map["lng"] = geoPoint?.longitude
+
+        return map
+    }
+
+    public static func convertToMap(email: BarcodeEmail) -> Any! {
+        var map: [String: Any] = [:]
+
+        map["address"] = email?.address
+        map["body"] = email?.body
+        map["subject"] = email?.subject
+        map["type"] = email?.type
+
+        return map
+    }
+
+    public static func convertToMap(name: BarcodePersonName) -> Any! {
+        var map: [String: Any] = [:]
+
+        map["first"] = name?.first
+        map["formattedName"] = name?.formattedName
+        map["last"] = name?.last
+        map["middle"] = name?.middle
+        map["prefix"] = name?.prefix
+        map["pronunciation"] = name?.pronunciation
+        map["suffix"] = name?.suffix
+
+        return map
+    }
+
+    public static func convertToMap(driverLicense: BarcodeDriverLicense) -> Any! {
+        var map: [String: Any] = [:]
+
+        map["addressCity"] = driverLicense?.addressCity
+        map["addressState"] = driverLicense?.addressState
+        map["addressStreet"] = driverLicense?.addressStreet
+        map["addressZip"] = driverLicense?.addressZip
+        map["birthDate"] = driverLicense?.birthDate
+        map["documentType"] = driverLicense?.documentType
+        map["expiryDate"] = driverLicense?.expiryDate
+        map["firstName"] = driverLicense?.firstName
+        map["gender"] = driverLicense?.gender
+        map["issueDate"] = driverLicense?.issueDate
+        map["issuingCountry"] = driverLicense?.issuingCountry
+        map["lastName"] = driverLicense?.lastName
+        map["licenseNumber"] = driverLicense?.licenseNumber
+        map["middleName"] = driverLicense?.middleName
+
+        return map
+    }
+
+    public static func convertToMap(address: BarcodeAddress) -> Any! {
+        var map: [String: Any] = [:]
+
+        map["addressLines"] = address?.addressLines
+        map["type"] = address?.type
+
+        return map
+    }
+
+    public static func convertToMap(calendarEvent: BarcodeCalendarEvent) -> Any! {
+        var map: [String: Any] = [:]
+
+        map["description"] = calendarEvent?.eventDescription
+        map["end"] = calendarEvent?.end
+        map["location"] = calendarEvent?.location
+        map["organizer"] = calendarEvent?.organizer
+        map["start"] = calendarEvent?.start
+        map["status"] = calendarEvent?.status
+        map["summary"] = calendarEvent?.summary
+
+        return map
+    }
+
+    public static func convertToMap(contactInfo: BarcodeContactInfo) -> Any! {
+        var map: [String: Any] = [:]
+
+        map["addresses"] = contactInfo?.addresses
+        map["emails"] = contactInfo?.emails
+        map["name"] = BarcodeConverter.convertToMap(contactInfo?.name)
+        map["organization"] = contactInfo?.organization
+        map["phones"] = contactInfo?.phones
+        map["title"] = contactInfo?.jobTitle
+        map["urls"] = contactInfo?.urls
+
+        return map
+    }
+}
+}

--- a/ios/VisionCameraQrcodeScanner.swift
+++ b/ios/VisionCameraQrcodeScanner.swift
@@ -9,37 +9,64 @@ class VisionCameraQrcodeScanner: NSObject, FrameProcessorPluginBase {
     static var barcodeScanner = BarcodeScanner.barcodeScanner(options: barcodeOptions)
     
     @objc
-     public static func callback(_ frame: Frame!, withArgs _: [Any]!) -> Any! {
-       
-       let image = VisionImage(buffer: frame.buffer)
-       image.orientation = .up
-       var barCodeAttributes: [Any] = []
+    public static func callback(_ frame: Frame!, withArgs _: [Any]!) -> Any! {
+        let image = VisionImage(buffer: frame.buffer)
+        image.orientation = .up
+        var barCodeAttributes: [Any] = []
         
-       do {
-           let barcodes: [Barcode] =  try barcodeScanner.results(in: image)
-           if (!barcodes.isEmpty){
+        do {
+            let barcodes: [Barcode] =  try barcodeScanner.results(in: image)
+            if (!barcodes.isEmpty){
                 for barcode in barcodes {
-                   var map: [String: Any] = [:]
-                   switch barcode.valueType {
-                   case .URL:
-                       map["title"] = barcode.url?.title
-                       map["url"] = barcode.url?.url
-                   case .wiFi:
-                       map["password"] = barcode.wifi?.password
-                       map["encryptionType"] = barcode.wifi?.type
-                       map["ssid"] = barcode.wifi?.ssid
-                   default:
-                       // TODO: implement all valueTypes https://developers.google.com/ml-kit/reference/swift/mlkitbarcodescanning/api/reference/Classes/Barcode
-                       map = [:]
-                   }
-                   barCodeAttributes.append(map)
-                 }
-           }
-         } catch _ {
-               return nil
-         }
-       
-       return barCodeAttributes
+                    barCodeAttributes.append(convertBarcode(barcode))
+                }
+            }
+        } catch _ {
+            return nil
+        }
         
+        return barCodeAttributes
+    }
+
+    func convertContent(barcode: Barcode) -> Any! {
+        var map: [String: Any] = [:]
+
+        map["type"] = barcode.valueType
+
+        switch barcode.valueType {
+            case .unknown, .ISBN, .text:
+                map["content"] = barcode.rawValue
+            case .contactInfo:
+                map["content"] = BarcodeConverter.convertToMap(barcode.contactInfo)
+            case .email:
+                map["content"] = BarcodeConverter.convertToMap(barcode.email)
+            case .phone:
+                map["content"] = BarcodeConverter.convertToMap(barcode.phone)
+            case .SMS:
+                map["content"] = BarcodeConverter.convertToMap(barcode.sms)
+            case .URL:
+                map["content"] = BarcodeConverter.convertToMap(barcode.url)
+            case .wiFi:
+                map["content"] = BarcodeConverter.convertToMap(barcode.wifi)
+            case .geographicCoordinates:
+                map["content"] = BarcodeConverter.convertToMap(barcode.geoPoint)
+            case .calendarEvent:
+                map["content"] = BarcodeConverter.convertToMap(barcode.calendarEvent)
+            case .driversLicense:
+                map["content"] = BarcodeConverter.convertToMap(barcode.driverLicense)
+        }
+
+        return map
+    }
+
+    func convertBarcode(barcode: Barcode) -> Any! {
+        var map: [String: Any] = [:]
+
+        map["cornerPoints"] = barcode.cornerPoints
+        map["displayValue"] = barcode.displayValue
+        map["rawValue"] = barcode.rawValue
+        map["content"] = convertContent(barcode)
+
+        return map
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,7 @@ export interface QrCodePersonName {
 export interface QrCodeContactInfo {
   addresses?: QrCodeAddress[];
   emails?: QrCodeEmail[];
-  name?: QrCodePersonName[];
+  name?: QrCodePersonName;
   organization?: string;
   phones?: QrCodePhone[];
   title?: string;
@@ -146,8 +146,13 @@ export interface QrCodeGeoPoint {
  * @see https://developers.google.com/android/reference/com/google/mlkit/vision/barcode/Barcode.CalendarDateTime
  */
 export interface QrCodeDate {
-  seconds: number;
+  day: number;
+  hours: number;
+  minutes: number;
+  month: number;
   rawValue: string;
+  seconds: number;
+  year: number;
   isUtc: boolean;
 }
 
@@ -209,6 +214,7 @@ export type QrCode = {
   boundingBox?: Rect;
   cornerPoints?: Point[];
   displayValue?: string;
+  rawValue?: string;
   content:
     | {
         type: QrCodeType.UNKNOWN;

--- a/src/index.ts
+++ b/src/index.ts
@@ -217,7 +217,7 @@ export type QrCode = {
   rawValue?: string;
   content:
     | {
-        type: QrCodeType.UNKNOWN;
+        type: QrCodeType.UNKNOWN | QrCodeType.ISBN | QrCodeType.TEXT;
         data: string;
       }
     | {
@@ -229,20 +229,12 @@ export type QrCode = {
         data: QrCodeEmail;
       }
     | {
-        type: QrCodeType.ISBN;
-        data: string;
-      }
-    | {
         type: QrCodeType.PHONE;
         data: QrCodePhone;
       }
     | {
         type: QrCodeType.SMS;
         data: QrCodeSms;
-      }
-    | {
-        type: QrCodeType.TEXT;
-        data: string;
       }
     | {
         type: QrCodeType.URL;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,268 @@
 import type { Frame } from 'react-native-vision-camera';
 
 /**
- * Scans QR codes.
+ * @see https://developers.google.com/android/reference/com/google/mlkit/vision/barcode/Barcode.BarcodeValueType
  */
+export enum QrCodeType {
+  UNKNOWN = 0,
+  CONTACT_INFO = 1,
+  EMAIL = 2,
+  ISBN = 3,
+  PHONE = 4,
+  PRODUCT = 5,
+  SMS = 6,
+  TEXT = 7,
+  URL = 8,
+  WIFI = 9,
+  GEO = 10,
+  CALENDAR_EVENT = 11,
+  DRIVER_LICENSE = 12,
+}
 
-export interface QrCode {
+/**
+ * @see https://developers.google.com/android/reference/com/google/mlkit/vision/barcode/Barcode.Address.AddressType
+ */
+export enum QrCodeAddressType {
+  UNKNOWN = 0,
+  WORK = 1,
+  HOME = 2,
+}
+
+/**
+ * @see https://developers.google.com/android/reference/com/google/mlkit/vision/barcode/Barcode.Address
+ */
+export interface QrCodeAddress {
+  addressLines?: string[];
+  type?: QrCodeAddressType;
+}
+
+/**
+ * @see https://developers.google.com/android/reference/com/google/mlkit/vision/barcode/Barcode.PersonName
+ */
+export interface QrCodePersonName {
+  first?: string;
+  formattedName?: string;
+  last?: string;
+  middle?: string;
+  prefix?: string;
+  pronunciation?: string;
+  suffix?: string;
+}
+
+/**
+ * @see https://developers.google.com/android/reference/com/google/mlkit/vision/barcode/Barcode.ContactInfo
+ */
+export interface QrCodeContactInfo {
+  addresses?: QrCodeAddress[];
+  emails?: QrCodeEmail[];
+  name?: QrCodePersonName[];
+  organization?: string;
+  phones?: QrCodePhone[];
+  title?: string;
+  urls?: string[];
+}
+
+/**
+ * @see https://developers.google.com/android/reference/com/google/mlkit/vision/barcode/Barcode.Email.FormatType
+ */
+export enum QrCodeEmailType {
+  UNKNOWN = 0,
+  WORK = 1,
+  HOME = 2,
+}
+
+/**
+ * @see https://developers.google.com/android/reference/com/google/mlkit/vision/barcode/Barcode.Email
+ */
+export interface QrCodeEmail {
+  address?: string;
+  body?: string;
+  subject?: string;
+  type?: QrCodeEmailType;
+}
+
+/**
+ * @see https://developers.google.com/android/reference/com/google/mlkit/vision/barcode/Barcode.Phone.FormatType
+ */
+export enum QrCodePhoneType {
+  UNKNOWN = 0,
+  WORK = 1,
+  HOME = 2,
+  FAX = 3,
+  MOBILE = 4,
+}
+
+/**
+ * @see https://developers.google.com/android/reference/com/google/mlkit/vision/barcode/Barcode.Phone
+ */
+export interface QrCodePhone {
+  number?: string;
+  type?: QrCodePhoneType;
+}
+
+/**
+ * @see https://developers.google.com/android/reference/com/google/mlkit/vision/barcode/Barcode.Sms
+ */
+export interface QrCodeSms {
+  message?: string;
+  phoneNumber?: string;
+}
+
+/**
+ * @see https://developers.google.com/android/reference/com/google/mlkit/vision/barcode/Barcode.UrlBookmark
+ */
+export interface QrCodeUrl {
   title?: string;
   url?: string;
+}
+
+/**
+ * @see https://developers.google.com/android/reference/com/google/mlkit/vision/barcode/Barcode.WiFi.EncryptionType
+ */
+export enum QrCodeWifiType {
+  OPEN = 1,
+  WPA = 2,
+  WEP = 3,
+}
+
+/**
+ * @see https://developers.google.com/android/reference/com/google/mlkit/vision/barcode/Barcode.WiFi
+ */
+export interface QrCodeWifi {
+  encryptionType?: QrCodeWifiType;
   password?: string;
-  encryptionType?: string;
   ssid?: string;
 }
 
+/**
+ * @see https://developers.google.com/android/reference/com/google/mlkit/vision/barcode/Barcode.GeoPoint
+ */
+export interface QrCodeGeoPoint {
+  lat?: number;
+  lng?: number;
+}
+
+/**
+ * @see https://developers.google.com/android/reference/com/google/mlkit/vision/barcode/Barcode.CalendarDateTime
+ */
+export interface QrCodeDate {
+  seconds: number;
+  rawValue: string;
+  isUtc: boolean;
+}
+
+/**
+ * @see https://developers.google.com/android/reference/com/google/mlkit/vision/barcode/Barcode.CalendarEvent
+ */
+export interface QrCodeCalendarEvent {
+  description?: string;
+  end?: QrCodeDate;
+  location?: string;
+  organizer?: string;
+  start?: QrCodeDate;
+  status?: string;
+  summary?: string;
+}
+
+/**
+ * @see https://developers.google.com/android/reference/com/google/mlkit/vision/barcode/Barcode.DriverLicense
+ */
+export interface QrCodeDriverLicense {
+  addressCity?: string;
+  addressState?: string;
+  addressStreet?: string;
+  addressZip?: string;
+  birthDate?: string;
+  documentType?: string;
+  expiryDate?: string;
+  firstName?: string;
+  gender?: string;
+  issueDate?: string;
+  issuingCountry?: string;
+  lastName?: string;
+  licenseNumber?: string;
+  middleName?: string;
+}
+
+/**
+ * @see https://developer.android.com/reference/android/graphics/Rect.html
+ */
+export interface Rect {
+  bottom: number;
+  left: number;
+  right: number;
+  top: number;
+}
+
+/**
+ * @see https://developer.android.com/reference/android/graphics/Point.html
+ */
+export interface Point {
+  x: number;
+  y: number;
+}
+
+/**
+ * @see https://developers.google.com/android/reference/com/google/mlkit/vision/barcode/Barcode
+ */
+export type QrCode = {
+  boundingBox?: Rect;
+  cornerPoints?: Point[];
+  displayValue?: string;
+  content:
+    | {
+        type: QrCodeType.UNKNOWN;
+        data: string;
+      }
+    | {
+        type: QrCodeType.CONTACT_INFO;
+        data: QrCodeContactInfo;
+      }
+    | {
+        type: QrCodeType.EMAIL;
+        data: QrCodeEmail;
+      }
+    | {
+        type: QrCodeType.ISBN;
+        data: string;
+      }
+    | {
+        type: QrCodeType.PHONE;
+        data: QrCodePhone;
+      }
+    | {
+        type: QrCodeType.SMS;
+        data: QrCodeSms;
+      }
+    | {
+        type: QrCodeType.TEXT;
+        data: string;
+      }
+    | {
+        type: QrCodeType.URL;
+        data: QrCodeUrl;
+      }
+    | {
+        type: QrCodeType.WIFI;
+        data: QrCodeWifi;
+      }
+    | {
+        type: QrCodeType.GEO;
+        data: QrCodeGeoPoint;
+      }
+    | {
+        type: QrCodeType.CALENDAR_EVENT;
+        data: QrCodeCalendarEvent;
+      }
+    | {
+        type: QrCodeType.DRIVER_LICENSE;
+        data: QrCodeDriverLicense;
+      };
+};
+
+/**
+ * Scans QR codes.
+ */
 export function scanQRCodes(frame: Frame): QrCode[] {
   'worklet';
   // @ts-ignore


### PR DESCRIPTION
### Changes
This PR adds support for all of ML Kit data types returning QR code data in the following format:

```ts
{
  boundingBox?: Rect;
  cornerPoints?: Point[];
  displayValue?: string;
  rawValue?: string;
  content: {
    type: QrCodeType;
    data: string | QrCodeContactInfo | QrCodeEmail | QrCodePhone | QrCodeSms | QrCodeUrl | QrCodeWifi | QrCodeGeoPoint | QrCodeCalendarEvent | QrCodeDriverLicense;
  }
}
```

### Testing

#### Android
I've tested successfully the Android part on my phone with every type, except the UNKNOWN, ISBN, PRODUCT and DRIVER_LICENSE ones (since I'm not sure how to test them), but they should technically work. 

I'm aware that the Java code looks a bit repetitive, but I'm not sure how to do it otherwise, feel free to leave some comments :)

#### iOS
I've never touched Swift before and since I don't own a Mac, I was not able to test the iOS part of it. Feel free to change as you see fit.

> As a side question, since adding support to other types of barcodes seems to be as straightforward as passing an array with those types, would you see this being another reasonable addition to this package? If so I can whip up another PR with that change

### Related Issues
closes #1