### PR TITLE
fix: use data in qr code type

### DIFF
--- a/android/src/main/java/com/visioncameraqrcodescanner/VisionCameraQrcodeScannerPlugin.java
+++ b/android/src/main/java/com/visioncameraqrcodescanner/VisionCameraQrcodeScannerPlugin.java
@@ -70,34 +70,34 @@ public class VisionCameraQrcodeScannerPlugin extends FrameProcessorPlugin {
       case Barcode.TYPE_UNKNOWN:
       case Barcode.TYPE_ISBN:
       case Barcode.TYPE_TEXT:
-        map.putString("content", barcode.getRawValue());
+        map.putString("data", barcode.getRawValue());
         break;
       case Barcode.TYPE_CONTACT_INFO:
-        map.putMap("content", convertToMap(barcode.getContactInfo()));
+        map.putMap("data", convertToMap(barcode.getContactInfo()));
         break;
       case Barcode.TYPE_EMAIL:
-        map.putMap("content", convertToMap(barcode.getEmail()));
+        map.putMap("data", convertToMap(barcode.getEmail()));
         break;
       case Barcode.TYPE_PHONE:
-        map.putMap("content", convertToMap(barcode.getPhone()));
+        map.putMap("data", convertToMap(barcode.getPhone()));
         break;
       case Barcode.TYPE_SMS:
-        map.putMap("content", convertToMap(barcode.getSms()));
+        map.putMap("data", convertToMap(barcode.getSms()));
         break;
       case Barcode.TYPE_URL:
-        map.putMap("content", convertToMap(barcode.getUrl()));
+        map.putMap("data", convertToMap(barcode.getUrl()));
         break;
       case Barcode.TYPE_WIFI:
-        map.putMap("content", convertToMap(barcode.getWifi()));
+        map.putMap("data", convertToMap(barcode.getWifi()));
         break;
       case Barcode.TYPE_GEO:
-        map.putMap("content", convertToMap(barcode.getGeoPoint()));
+        map.putMap("data", convertToMap(barcode.getGeoPoint()));
         break;
       case Barcode.TYPE_CALENDAR_EVENT:
-        map.putMap("content", convertToMap(barcode.getCalendarEvent()));
+        map.putMap("data", convertToMap(barcode.getCalendarEvent()));
         break;
       case Barcode.TYPE_DRIVER_LICENSE:
-        map.putMap("content", convertToMap(barcode.getDriverLicense()));
+        map.putMap("data", convertToMap(barcode.getDriverLicense()));
         break;
     }
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -422,7 +422,7 @@ PODS:
   - RNScreens (3.5.0):
     - React-Core
     - React-RCTImage
-  - vision-camera-qrcode-scanner (0.1.3):
+  - vision-camera-qrcode-scanner (0.1.5):
     - GoogleMLKit/BarcodeScanning
     - React-Core
   - VisionCamera (2.7.0):
@@ -644,7 +644,7 @@ SPEC CHECKSUMS:
   ReactCommon: eafed38eec7b591c31751bfa7494801618460459
   RNReanimated: 48e578538b2fad573d3d5ce2e80ad375e1534d87
   RNScreens: 01ab149b5dd5c27f5ff26741b1d2bdf2cee1af35
-  vision-camera-qrcode-scanner: 65cf7fd57e33c0ac7b0503769d8c2711d18502c6
+  vision-camera-qrcode-scanner: 64bcfdad2be941ee66ea0a69ca816ca191d51cd3
   VisionCamera: 575e691d9eda91dce798f9958770b39841bbd981
   Yoga: aa0cb45287ebe1004c02a13f279c55a95f1572f4
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a

--- a/ios/VisionCameraQrcodeScanner.swift
+++ b/ios/VisionCameraQrcodeScanner.swift
@@ -35,25 +35,25 @@ class VisionCameraQrcodeScanner: NSObject, FrameProcessorPluginBase {
         
         switch barcode.valueType {
         case .unknown, .ISBN, .text:
-            map["content"] = barcode.rawValue
+            map["data"] = barcode.rawValue
         case .contactInfo:
-            map["content"] = BarcodeConverter.convertToMap(contactInfo: barcode.contactInfo)
+            map["data"] = BarcodeConverter.convertToMap(contactInfo: barcode.contactInfo)
         case .email:
-            map["content"] = BarcodeConverter.convertToMap(email: barcode.email)
+            map["data"] = BarcodeConverter.convertToMap(email: barcode.email)
         case .phone:
-            map["content"] = BarcodeConverter.convertToMap(phone: barcode.phone)
+            map["data"] = BarcodeConverter.convertToMap(phone: barcode.phone)
         case .SMS:
-            map["content"] = BarcodeConverter.convertToMap(sms: barcode.sms)
+            map["data"] = BarcodeConverter.convertToMap(sms: barcode.sms)
         case .URL:
-            map["content"] = BarcodeConverter.convertToMap(url: barcode.url)
+            map["data"] = BarcodeConverter.convertToMap(url: barcode.url)
         case .wiFi:
-            map["content"] = BarcodeConverter.convertToMap(wifi: barcode.wifi)
+            map["data"] = BarcodeConverter.convertToMap(wifi: barcode.wifi)
         case .geographicCoordinates:
-            map["content"] = BarcodeConverter.convertToMap(geoPoint: barcode.geoPoint)
+            map["data"] = BarcodeConverter.convertToMap(geoPoint: barcode.geoPoint)
         case .calendarEvent:
-            map["content"] = BarcodeConverter.convertToMap(calendarEvent: barcode.calendarEvent)
+            map["data"] = BarcodeConverter.convertToMap(calendarEvent: barcode.calendarEvent)
         case .driversLicense:
-            map["content"] = BarcodeConverter.convertToMap(driverLicense: barcode.driverLicense)
+            map["data"] = BarcodeConverter.convertToMap(driverLicense: barcode.driverLicense)
         default:
             map = [:]
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vision-camera-qrcode-scanner",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "VisionCamera Frame Processor Plugin to read barcodes using MLKit Vision Barcode Scanning",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",


### PR DESCRIPTION
## Changes
- Update the `convertContent` function in both iOS and Android to write to `content["data"]` as per the QrCode type, instead of `content["content"]`

## Related Issues
Closes https://github.com/rodgomesc/vision-camera-qrcode-scanner/issues/10
