### PR TITLE
(IOS) Use OptionSet to compare previously set format options to current options

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -10,7 +10,7 @@ export default function App() {
   const devices = useCameraDevices();
   const device = devices.back;
 
-  const [frameProcessor, barcodes] = useScanBarcodes([BarcodeFormat.QR_CODE]);
+  const [frameProcessor, barcodes] = useScanBarcodes([BarcodeFormat.ALL_FORMATS]);
 
   React.useEffect(() => {
     (async () => {

--- a/ios/VisionCameraQrcodeScanner.swift
+++ b/ios/VisionCameraQrcodeScanner.swift
@@ -5,7 +5,7 @@ import MLKitVision
 class VisionCameraQrcodeScanner: NSObject, FrameProcessorPluginBase {
     
     static var barcodeScanner: BarcodeScanner?
-    static var barcodeRawFormats: [Int]?
+    static var barcodeFormatOptionSet: BarcodeFormat = []
     
     @objc
     public static func callback(_ frame: Frame!, withArgs args: [Any]!) -> Any! {
@@ -31,14 +31,19 @@ class VisionCameraQrcodeScanner: NSObject, FrameProcessorPluginBase {
         guard let rawFormats = args[0] as? [Int] else {
             throw BarcodeError.noBarcodeFormatProvided
         }
-        if (barcodeScanner == nil || barcodeRawFormats != rawFormats) {
-            var formats: [BarcodeFormat] = []
-            rawFormats.forEach { rawFormat in
-                formats.append(BarcodeFormat(rawValue: rawFormat))
+        var formatOptionSet: BarcodeFormat = []
+        rawFormats.forEach { rawFormat in
+            if (rawFormat == 0) {
+                // ALL is a special case, since the Android and iOS option raw values don't match
+                formatOptionSet.insert(.all)
+            } else {
+                formatOptionSet.insert(BarcodeFormat(rawValue: rawFormat))
             }
-            let barcodeOptions = BarcodeScannerOptions(formats: BarcodeFormat(formats))
+        }
+        if (barcodeScanner == nil || barcodeFormatOptionSet != formatOptionSet) {
+            let barcodeOptions = BarcodeScannerOptions(formats: formatOptionSet)
             barcodeScanner = BarcodeScanner.barcodeScanner(options: barcodeOptions)
-            barcodeRawFormats = rawFormats
+            barcodeFormatOptionSet = formatOptionSet
         }
     }
     


### PR DESCRIPTION
This also has a fix for the `ALL_FORMATS` barcode option, which has a different raw value on iOS (`0xFFFF`) than it has on Android (`0`).