### PR TITLE
feat(zoom): fix missing neutralZoom for newer iPhones

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ export default function App() {
           isActive={true}
           frameProcessor={frameProcessor}
           frameProcessorFps={5}
+          zoom={device?.neutralZoom ?? 1}
         />
         {barcodes.map((barcode, idx) => (
           <Text key={idx} style={styles.barcodeTextURL}>

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -36,6 +36,7 @@ export default function App() {
           isActive={true}
           frameProcessor={frameProcessor}
           frameProcessorFps={5}
+          zoom={device?.neutralZoom ?? 1}
         />
         {barcodes.map((barcode, idx) => (
           <Text key={idx} style={styles.barcodeTextURL}>


### PR DESCRIPTION
Newer iPhones have neutralZoom of 2 and therefore cannot find small QR-Codes if zoom is at it's default value 1. This commit uses the device neutralZoom property as the default zoom level. Fixes #76.