### PR TITLE
🔧 Updated android compile + target SDK version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         }
 
         dependencies {
-            classpath 'com.android.tools.build:gradle:4.2.1'
+            classpath 'com.android.tools.build:gradle:7.3.1'
         }
     }
 }
@@ -18,11 +18,11 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
-    compileSdkVersion safeExtGet('VisionCameraCodeScanner_compileSdkVersion', 30)
+    compileSdkVersion safeExtGet('VisionCameraCodeScanner_compileSdkVersion', 33)
     ndkVersion "21.4.7075529"
     defaultConfig {
         minSdkVersion safeExtGet('VisionCameraCodeScanner_minSdkVersion', 21)
-        targetSdkVersion safeExtGet('VisionCameraCodeScanner_targetSdkVersion', 31)
+        targetSdkVersion safeExtGet('VisionCameraCodeScanner_targetSdkVersion', 33)
         versionCode 1
         versionName "1.0"
 


### PR DESCRIPTION
Fix for Android assembleRelease failure: Android resource linking failed lStar not found

Error stack: 
```
Execution failed for task ':vision-camera-code-scanner:verifyReleaseResources'.
> A failure occurred while executing com.android.build.gradle.tasks.VerifyLibraryResourcesTask$Action
   > Android resource linking failed
     ERROR:/................/node_modules/vision-camera-code-scanner/android/build/intermediates/merged_res/release/values/values.xml:2756: AAPT: error: resource android:attr/lStar not found.
         

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
==============================================================================

2: Task failed with an exception.
-----------
* What went wrong:
java.lang.StackOverflowError (no error message)
```
Issue started happening after upgrading `react-native` version to 0.71.7 from 0.67.5.

The issue happens when running `./gradlew assembleRelease` however, running `./gradlew app:assembleRelease` works as a workaround.

I tried the changes that I have made, and the project ran and I was able to build the app.  
